### PR TITLE
Make lockfile path dynamic in modern_replay_injector_ui.py auto-detect region function

### DIFF
--- a/modern_replay_injector_ui.py
+++ b/modern_replay_injector_ui.py
@@ -474,7 +474,7 @@ class ModernReplayInjectorGUI:
         """Auto-detect region from VALORANT config endpoint using lockfile"""
         try:
             # Read lockfile
-            lockfile_path = r"C:\Users\zachl\AppData\Local\Riot Games\Riot Client\Config\lockfile"
+            lockfile_path = os.path.join(os.environ["LOCALAPPDATA"], "Riot Games", "Riot Client", "Config", "lockfile")
             
             if not os.path.exists(lockfile_path):
                 messagebox.showerror("Error", "VALORANT lockfile not found. Please make sure VALORANT is running.")


### PR DESCRIPTION
I've modified line 477, and replaced the hardcoded path with a dynamic path to the lockfile, similarly done in other parts of the project.